### PR TITLE
Add option to force nifi to restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Role Variables
     # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
     nifi_perform_restart: True
 
+    # whether to force a restart, useful if another role has made changes (such as updating a custom nar); default is False
+    nifi_force_restart: False
+
     # A complete list of IP addresses for each nodes within the nifi cluster
     nifi_nodes_list: []
     

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ nifi_pid_dir: /var/run/nifi
 # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
 nifi_perform_restart: True
 
+# whether to force a restart, useful if another role has made changes (such as updating a custom nar); default is False
+nifi_force_restart: False
+
 # A complete list of IP addresses for each nodes within the nifi cluster
 nifi_nodes_list: []
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,7 @@
 
 - name: reload systemctl
   command: systemctl daemon-reload
+
 - name: restart nifi
   service: name=nifi state=restarted enabled=yes
   when: nifi_perform_restart

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -30,3 +30,7 @@
 
 - name: Ensure NiFi is running
   service: name=nifi state=started enabled=yes
+
+- name: Ensure NiFi is restarted
+  service: name=nifi state=restarted
+  when: nifi_force_restart


### PR DESCRIPTION
Added a flag called `nifi_force_restart` to force a restart. This is needed when another role makes changes (such as updating a custom nar) that require nifi to be restarted, even when this role itself does not make changes.