### PR TITLE
[NIFI-9] Updated configs to account for zookeeper nodes independently

### DIFF
--- a/templates/1.3/nifi.properties.j2
+++ b/templates/1.3/nifi.properties.j2
@@ -51,7 +51,7 @@ nifi.state.management.provider.local=local-provider
 # The ID of the cluster-wide state provider. This will be ignored if NiFi is not clustered but must be populated if running in a cluster.
 nifi.state.management.provider.cluster=zk-provider
 # Specifies whether or not this instance of NiFi should run an embedded ZooKeeper server
-{% set is_zk_node = nifi_nodes_list[0:3] | intersect([ec2_private_ip_address]) | length > 0 -%}
+{% set is_zk_node = nifi_zookeeper_servers | intersect([ec2_private_ip_address]) | length > 0 -%}
 {% set should_run_zk = nifi_state_management_embedded_zookeeper_start -%}
 nifi.state.management.embedded.zookeeper.start={{ (is_zk_node and should_run_zk) | lower }}
 # Properties file that provides the ZooKeeper properties to use if <nifi.state.management.embedded.zookeeper.start> is set to true
@@ -210,25 +210,17 @@ nifi.cluster.node.connection.timeout=5 sec
 nifi.cluster.node.read.timeout=5 sec
 nifi.cluster.firewall.file=
 nifi.cluster.flow.election.max.wait.time=5 mins
-{% if nifi_state_management_embedded_zookeeper_start -%}
-nifi.cluster.flow.election.max.candidates={{ nifi_nodes_list[0:3] | length }}
-{% else -%}
 {% if nifi_zookeeper_servers | length > 0 -%}
 nifi.cluster.flow.election.max.candidates={{ nifi_zookeeper_servers | length }}
 {% else -%}
 nifi.cluster.flow.election.max.candidates=
 {% endif -%}
-{% endif -%}
 
 # zookeeper properties, used for cluster management #
-{% if nifi_state_management_embedded_zookeeper_start -%}
-nifi.zookeeper.connect.string={{ nifi_nodes_list[0:3] | join(':2181,') }}:2181
-{% else -%}
 {% if nifi_zookeeper_servers | length > 0 -%}
 nifi.zookeeper.connect.string={{ nifi_zookeeper_servers | join(':2181,') }}:2181
 {% else -%}
 nifi.zookeeper.connect.string=
-{% endif -%}
 {% endif -%}
 nifi.zookeeper.connect.timeout=3 secs
 nifi.zookeeper.session.timeout=3 secs

--- a/templates/1.3/zookeeper.properties.j2
+++ b/templates/1.3/zookeeper.properties.j2
@@ -39,6 +39,6 @@ autopurge.snapRetainCount={{ nifi_zookeeper_autopurge_snapRetainCount }}
 # in the dataDir of each node running an embedded zookeeper. See the
 # administration guide for more details.
 #
-{% for node_ip in nifi_nodes_list[0:3] -%}
+{% for node_ip in nifi_zookeeper_servers -%}
 server.{{  node_ip | splitext | last | replace('.', '') }}={{ node_ip }}:2888:3888
 {% endfor -%}

--- a/templates/1.4/authorizers.xml.j2
+++ b/templates/1.4/authorizers.xml.j2
@@ -49,7 +49,7 @@
         <property name="Users File">{{ nifi_conf_dir }}/users.xml</property>
         <property name="Legacy Authorized Users File"></property>
 
-        <property name="Initial User Identity A"></property>
+        <property name="Initial User Identity A">{{ nifi_initial_admin }}</property>
         {% if nifi_nodes_list | length > 0 -%}
         {% for node in nifi_nodes_list -%}
         <property name="Initial User Identity {{ loop.index }}">CN={{ node }}, OU=NIFI</property>

--- a/templates/1.4/nifi.properties.j2
+++ b/templates/1.4/nifi.properties.j2
@@ -49,7 +49,7 @@ nifi.state.management.provider.local=local-provider
 # The ID of the cluster-wide state provider. This will be ignored if NiFi is not clustered but must be populated if running in a cluster.
 nifi.state.management.provider.cluster=zk-provider
 # Specifies whether or not this instance of NiFi should run an embedded ZooKeeper server
-{% set is_zk_node = nifi_nodes_list[0:3] | intersect([ec2_private_ip_address]) | length > 0 -%}
+{% set is_zk_node = nifi_zookeeper_servers | intersect([ec2_private_ip_address]) | length > 0 -%}
 {% set should_run_zk = nifi_state_management_embedded_zookeeper_start -%}
 nifi.state.management.embedded.zookeeper.start={{ (is_zk_node and should_run_zk) | lower }}
 # Properties file that provides the ZooKeeper properties to use if <nifi.state.management.embedded.zookeeper.start> is set to true
@@ -178,7 +178,7 @@ nifi.security.truststore=
 nifi.security.truststoreType=
 nifi.security.truststorePasswd=
 {% endif -%}
-nifi.security.needClientAuth=
+nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=
@@ -218,25 +218,17 @@ nifi.cluster.node.read.timeout=5 sec
 nifi.cluster.node.max.concurrent.requests=100
 nifi.cluster.firewall.file=
 nifi.cluster.flow.election.max.wait.time=5 mins
-{% if nifi_state_management_embedded_zookeeper_start -%}
-nifi.cluster.flow.election.max.candidates={{ nifi_nodes_list[0:3] | length }}
-{% else -%}
 {% if nifi_zookeeper_servers | length > 0 -%}
 nifi.cluster.flow.election.max.candidates={{ nifi_zookeeper_servers | length }}
 {% else -%}
 nifi.cluster.flow.election.max.candidates=
 {% endif -%}
-{% endif -%}
 
 # zookeeper properties, used for cluster management #
-{% if nifi_state_management_embedded_zookeeper_start -%}
-nifi.zookeeper.connect.string={{ nifi_nodes_list[0:3] | join(':2181,') }}:2181
-{% else -%}
 {% if nifi_zookeeper_servers | length > 0 -%}
 nifi.zookeeper.connect.string={{ nifi_zookeeper_servers | join(':2181,') }}:2181
 {% else -%}
 nifi.zookeeper.connect.string=
-{% endif -%}
 {% endif -%}
 nifi.zookeeper.connect.timeout=3 secs
 nifi.zookeeper.session.timeout=3 secs

--- a/templates/1.4/state-management.xml.j2
+++ b/templates/1.4/state-management.xml.j2
@@ -58,14 +58,10 @@
     <cluster-provider>
         <id>zk-provider</id>
         <class>org.apache.nifi.controller.state.providers.zookeeper.ZooKeeperStateProvider</class>
-        {% if nifi_state_management_embedded_zookeeper_start -%}
-        <property name="Connect String">{{ nifi_nodes_list[0:3] | join(':2181,') }}:2181</property>
-        {% else -%}
         {% if nifi_zookeeper_servers | length > 0 -%}
         <property name="Connect String">{{ nifi_zookeeper_servers | join(':2181,') }}:2181</property>
         {% else -%}
         <property name="Connect String"></property>
-        {% endif -%}
         {% endif -%}
         <property name="Root Node">{{ nifi_zookeeper_root_node }}</property>
         <property name="Session Timeout">{{ nifi_zookeeper_session_timeout }}</property>

--- a/templates/1.4/zookeeper.properties.j2
+++ b/templates/1.4/zookeeper.properties.j2
@@ -41,6 +41,6 @@ autopurge.snapRetainCount={{ nifi_zookeeper_autopurge_snapRetainCount }}
 # in the dataDir of each node running an embedded zookeeper. See the
 # administration guide for more details.
 #
-{% for node_ip in nifi_nodes_list[0:3] -%}
+{% for node_ip in nifi_zookeeper_servers -%}
 server.{{  node_ip | splitext | last | replace('.', '') }}={{ node_ip }}:2888:3888
 {% endfor -%}


### PR DESCRIPTION
[NIFI-9] Updated configs to account for zookeeper nodes independently from the list of NiFi nodes, making it easier to lock down a NiFi cluster.