### PR TITLE
[NIFI-13] split nifi_input_socket_host into multiple parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Role Variables
     nifi_force_restart: False
 
     # A complete list of IP addresses for each nodes within the nifi cluster
-    nifi_nodes_list: []
+    nifi_authorized_nodes_list: []
     
     # nifi_extra_args is a list of key/value pairs that are made available in NiFi, for example:
     nifi_extra_args:
@@ -149,7 +149,7 @@ Install and configure NiFi
           nifi_node_jvm_memory: '10240M'
           nifi_custom_nars: [ '/opt/extra-nars' ]
           nifi_single_node: False
-          nifi_nodes_list: ['nifi-node-1', 'nifi-node-2']      
+          nifi_authorized_nodes_list: ['nifi-node-1', 'nifi-node-2']      
       pre_tasks:
         - name: Upload NiFi distribution (tar.gz) from localhost
           copy:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ nifi_perform_restart: True
 nifi_force_restart: False
 
 # A complete list of IP addresses for each nodes within the nifi cluster
-nifi_nodes_list: []
+nifi_authorized_nodes_list: []
 
 # extra arg that are useful in expression languages
 nifi_extra_args: []
@@ -32,12 +32,18 @@ nifi_flowfile_repository: "{{ nifi_home }}/flowfile_repository"
 nifi_content_repositories: [ "{{ nifi_home }}/content_repository" ]
 nifi_provenance_repositories: [ "{{ nifi_home }}/provenance_repository" ]
 
+# Web properties
+nifi_input_socket_host:
+nifi_web_http_port: 8080
+
 # NiFi cluster settings
 nifi_single_node: True
-nifi_input_socket_host:
-nifi_input_socket_port:
+nifi_cluster_node_address:
 nifi_cluster_node_protocol_port:
-nifi_web_http_port: 8080
+
+# Site to Site properties
+nifi_remote_input_host:
+nifi_remote_input_socket_port:
 
 # Queue swap settings
 nifi_queue_swap_threshold: 20000

--- a/templates/1.3/authorizers.xml.j2
+++ b/templates/1.3/authorizers.xml.j2
@@ -55,8 +55,8 @@
         <property name="Users File">{{ nifi_conf_dir }}/users.xml</property>
         <property name="Initial Admin Identity">{{ nifi_initial_admin | default('') }}</property>
         <property name="Legacy Authorized Users File"></property>
-        {% if nifi_nodes_list | length > 0 -%}
-        {% for node in nifi_nodes_list -%}
+        {% if nifi_authorized_nodes_list | length > 0 -%}
+        {% for node in nifi_authorized_nodes_list -%}
         <property name="Node Identity {{ loop.index }}">CN={{ node }}, OU=NIFI</property>
         {% endfor -%}
         {% endif -%}

--- a/templates/1.3/nifi.properties.j2
+++ b/templates/1.3/nifi.properties.j2
@@ -130,9 +130,9 @@ nifi.components.status.repository.buffer.size={{ nifi_components_status_reposito
 nifi.components.status.snapshot.frequency={{ nifi_components_status_snapshot_frequency }}
 
 # Site to Site properties
-nifi.remote.input.host={{ nifi_input_socket_host }}
+nifi.remote.input.host={{ nifi_remote_input_host }}
 nifi.remote.input.secure={{ nifi_is_secure | lower }}
-nifi.remote.input.socket.port={{ nifi_input_socket_port }}
+nifi.remote.input.socket.port={{ nifi_remote_input_socket_port }}
 nifi.remote.input.http.enabled={{ (not nifi_is_secure) | lower }}
 nifi.remote.input.http.transaction.ttl=30 sec
 
@@ -201,7 +201,7 @@ nifi.cluster.protocol.is.secure={{ nifi_is_secure | lower }}
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node={{ (not nifi_single_node) | lower }}
-nifi.cluster.node.address={{ nifi_input_socket_host }}
+nifi.cluster.node.address={{ nifi_cluster_node_address }}
 nifi.cluster.node.protocol.port={{ nifi_cluster_node_protocol_port }}
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50

--- a/templates/1.4/authorizers.xml.j2
+++ b/templates/1.4/authorizers.xml.j2
@@ -50,8 +50,8 @@
         <property name="Legacy Authorized Users File"></property>
 
         <property name="Initial User Identity A">{{ nifi_initial_admin }}</property>
-        {% if nifi_nodes_list | length > 0 -%}
-        {% for node in nifi_nodes_list -%}
+        {% if nifi_authorized_nodes_list | length > 0 -%}
+        {% for node in nifi_authorized_nodes_list -%}
         <property name="Initial User Identity {{ loop.index }}">CN={{ node }}, OU=NIFI</property>
         {% endfor -%}
         {% endif -%}
@@ -238,8 +238,8 @@
         <property name="Initial Admin Identity">{{ nifi_initial_admin | default('') }}</property>
         <property name="Legacy Authorized Users File"></property>
 
-        {% if nifi_nodes_list | length > 0 -%}
-        {% for node in nifi_nodes_list -%}
+        {% if nifi_authorized_nodes_list | length > 0 -%}
+        {% for node in nifi_authorized_nodes_list -%}
         <property name="Node Identity {{ loop.index }}">CN={{ node }}, OU=NIFI</property>
         {% endfor -%}
         {% endif -%}
@@ -297,8 +297,8 @@
         <property name="Users File">{{ nifi_conf_dir }}/users.xml</property>
         <property name="Initial Admin Identity">{{ nifi_initial_admin | default('') }}</property>
         <property name="Legacy Authorized Users File"></property>
-        {% if nifi_nodes_list | length > 0 -%}
-        {% for node in nifi_nodes_list -%}
+        {% if nifi_authorized_nodes_list | length > 0 -%}
+        {% for node in nifi_authorized_nodes_list -%}
         <property name="Node Identity {{ loop.index }}">CN={{ node }}, OU=NIFI</property>
         {% endfor -%}
         {% endif -%}

--- a/templates/1.4/nifi.properties.j2
+++ b/templates/1.4/nifi.properties.j2
@@ -128,9 +128,9 @@ nifi.components.status.repository.buffer.size={{ nifi_components_status_reposito
 nifi.components.status.snapshot.frequency={{ nifi_components_status_snapshot_frequency }}
 
 # Site to Site properties
-nifi.remote.input.host={{ nifi_input_socket_host }}
+nifi.remote.input.host={{ nifi_remote_input_host }}
 nifi.remote.input.secure={{ nifi_is_secure | lower }}
-nifi.remote.input.socket.port={{ nifi_input_socket_port }}
+nifi.remote.input.socket.port={{ nifi_remote_input_socket_port }}
 nifi.remote.input.http.enabled={{ (not nifi_is_secure) | lower }}
 nifi.remote.input.http.transaction.ttl=30 sec
 
@@ -208,7 +208,7 @@ nifi.cluster.protocol.is.secure={{ nifi_is_secure | lower }}
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node={{ (not nifi_single_node) | lower }}
-nifi.cluster.node.address={{ nifi_input_socket_host }}
+nifi.cluster.node.address={{ nifi_cluster_node_address }}
 nifi.cluster.node.protocol.port={{ nifi_cluster_node_protocol_port }}
 nifi.cluster.node.protocol.threads=10
 nifi.cluster.node.protocol.max.threads=50


### PR DESCRIPTION
**nifi_input_socket_host** was split into **nifi_remote_input_host**, **nifi_cluster_node_address**.  **nifi_input_socket_host** is still used for nifi_web_http parameters