### PR TITLE
allowing java_home to be set as part of nifi-env.sh

### DIFF
--- a/templates/1.4/nifi-env.sh.j2
+++ b/templates/1.4/nifi-env.sh.j2
@@ -17,7 +17,11 @@
 #
 
 # The java implementation to use.
+{% if nifi_java_home is defined %}
+export JAVA_HOME={{ nifi_java_home }}
+{% else %}
 #export JAVA_HOME=/usr/java/jdk1.8.0/
+{% endif %}
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/templates/1.5/nifi-env.sh.j2
+++ b/templates/1.5/nifi-env.sh.j2
@@ -17,7 +17,11 @@
 #
 
 # The java implementation to use.
+{% if nifi_java_home is defined %}
+export JAVA_HOME={{ nifi_java_home }}
+{% else %}
 #export JAVA_HOME=/usr/java/jdk1.8.0/
+{% endif %}
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/templates/1.6/nifi-env.sh.j2
+++ b/templates/1.6/nifi-env.sh.j2
@@ -17,7 +17,11 @@
 #
 
 # The java implementation to use.
+{% if nifi_java_home is defined %}
+export JAVA_HOME={{ nifi_java_home }}
+{% else %}
 #export JAVA_HOME=/usr/java/jdk1.8.0/
+{% endif %}
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/templates/1.7/nifi-env.sh.j2
+++ b/templates/1.7/nifi-env.sh.j2
@@ -17,7 +17,11 @@
 #
 
 # The java implementation to use.
+{% if nifi_java_home is defined %}
+export JAVA_HOME={{ nifi_java_home }}
+{% else %}
 #export JAVA_HOME=/usr/java/jdk1.8.0/
+{% endif %}
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/templates/1.8/nifi-env.sh.j2
+++ b/templates/1.8/nifi-env.sh.j2
@@ -17,7 +17,11 @@
 #
 
 # The java implementation to use.
+{% if nifi_java_home is defined %}
+export JAVA_HOME={{ nifi_java_home }}
+{% else %}
 #export JAVA_HOME=/usr/java/jdk1.8.0/
+{% endif %}
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 


### PR DESCRIPTION
In certain situations, we need to be able to set JAVA_HOME as part of the nifi env.  