### PR TITLE
Add ability to specify java.io.tmpdir in bootstrap.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Role Variables
     
 ### Other Default variables are listed below:
 
-    # enable to specify -Djava.io.tmpdir in bootstrap.conf
-    #nifi_tmpdir: /tmp
+    # specify -Djava.io.tmpdir in bootstrap.conf, default is unspecified
+    #nifi_tmp_dir: /tmp
 
     # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
     nifi_perform_restart: True

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Role Variables
     
 ### Other Default variables are listed below:
 
+    # enable to specify -Djava.io.tmpdir in bootstrap.conf
+    #nifi_tmpdir: /tmp
+
     # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
     nifi_perform_restart: True
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ nifi_etc_dir: /etc/nifi
 nifi_log_dir: /var/log/nifi
 nifi_pid_dir: /var/run/nifi
 
+# optional: enable to specify -Djava.io.tmpdir in bootstrap.conf
+#nifi_tmpdir: /tmp
+
 # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
 nifi_perform_restart: True
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,8 @@ nifi_etc_dir: /etc/nifi
 nifi_log_dir: /var/log/nifi
 nifi_pid_dir: /var/run/nifi
 
-# optional: enable to specify -Djava.io.tmpdir in bootstrap.conf
-#nifi_tmpdir: /tmp
+# specify -Djava.io.tmpdir in bootstrap.conf, default is unspecified
+#nifi_tmp_dir: /tmp
 
 # whether to restart nifi after making changes; default is True, for a cluster you may wish to disable
 nifi_perform_restart: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,10 +34,10 @@
     - "{{ nifi_database_repository }}"
     - "{{ nifi_flowfile_repository }}"
 
-- name: Ensure nifi tmpdir exists
-  file: path="{{ nifi_tmpdir }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
+- name: Ensure nifi tmp_dir exists
+  file: path="{{ nifi_tmp_dir }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
   when:
-    - nifi_tmpdir is defined
+    - nifi_tmp_dir is defined
 
 - name: ensure nifi content repo directories exist
   file: path="{{ item }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,6 +34,11 @@
     - "{{ nifi_database_repository }}"
     - "{{ nifi_flowfile_repository }}"
 
+- name: Ensure nifi tmpdir exists
+  file: path="{{ nifi_tmpdir }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
+  when:
+    - nifi_tmpdir is defined
+
 - name: ensure nifi content repo directories exist
   file: path="{{ item }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
   with_items: "{{ nifi_content_repositories }}"

--- a/templates/1.3/bootstrap.conf.j2
+++ b/templates/1.3/bootstrap.conf.j2
@@ -57,6 +57,11 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.3/bootstrap.conf.j2
+++ b/templates/1.3/bootstrap.conf.j2
@@ -57,7 +57,7 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.3/bootstrap.conf.j2
+++ b/templates/1.3/bootstrap.conf.j2
@@ -57,11 +57,12 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.4/bootstrap.conf.j2
+++ b/templates/1.4/bootstrap.conf.j2
@@ -57,6 +57,11 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.4/bootstrap.conf.j2
+++ b/templates/1.4/bootstrap.conf.j2
@@ -57,7 +57,7 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.4/bootstrap.conf.j2
+++ b/templates/1.4/bootstrap.conf.j2
@@ -57,11 +57,12 @@ nifi.bootstrap.sensitive.key=
 # Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
 java.arg.15=-Djava.security.egd=file:/dev/urandom
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.5/bootstrap.conf.j2
+++ b/templates/1.5/bootstrap.conf.j2
@@ -61,7 +61,7 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.5/bootstrap.conf.j2
+++ b/templates/1.5/bootstrap.conf.j2
@@ -61,6 +61,11 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.5/bootstrap.conf.j2
+++ b/templates/1.5/bootstrap.conf.j2
@@ -61,11 +61,12 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.6/bootstrap.conf.j2
+++ b/templates/1.6/bootstrap.conf.j2
@@ -61,7 +61,7 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.6/bootstrap.conf.j2
+++ b/templates/1.6/bootstrap.conf.j2
@@ -61,6 +61,11 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.6/bootstrap.conf.j2
+++ b/templates/1.6/bootstrap.conf.j2
@@ -61,11 +61,12 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.7/bootstrap.conf.j2
+++ b/templates/1.7/bootstrap.conf.j2
@@ -61,7 +61,7 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.7/bootstrap.conf.j2
+++ b/templates/1.7/bootstrap.conf.j2
@@ -61,6 +61,11 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.7/bootstrap.conf.j2
+++ b/templates/1.7/bootstrap.conf.j2
@@ -61,11 +61,12 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.8/bootstrap.conf.j2
+++ b/templates/1.8/bootstrap.conf.j2
@@ -61,7 +61,7 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.8/bootstrap.conf.j2
+++ b/templates/1.8/bootstrap.conf.j2
@@ -61,6 +61,11 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.8/bootstrap.conf.j2
+++ b/templates/1.8/bootstrap.conf.j2
@@ -61,11 +61,12 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.9/bootstrap.conf.j2
+++ b/templates/1.9/bootstrap.conf.j2
@@ -61,7 +61,7 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir -%}
+{% if nifi_tmpdir is defined -%}
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
 java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
 {% endif -%}

--- a/templates/1.9/bootstrap.conf.j2
+++ b/templates/1.9/bootstrap.conf.j2
@@ -61,6 +61,11 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
+{% if nifi_tmpdir -%}
+# http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
+{% endif -%}
+
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###

--- a/templates/1.9/bootstrap.conf.j2
+++ b/templates/1.9/bootstrap.conf.j2
@@ -61,11 +61,12 @@ java.arg.15=-Djava.security.egd=file:/dev/urandom
 # Please see https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/single-signon.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.16=-Djavax.security.auth.useSubjectCredsOnly=true
 
-{% if nifi_tmpdir is defined -%}
+{% if nifi_tmp_dir is defined %}
+# Specify java.io.tmpdir to workaround
 # http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html
-java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmpdir }}
-{% endif -%}
+java.arg.tmpdir=-Djava.io.tmpdir={{ nifi_tmp_dir }}
 
+{% endif %}
 ###
 # Notification Services for notifying interested parties when NiFi is stopped, started, dies
 ###


### PR DESCRIPTION
Ran into this issue: http://apache-nifi-users-list.2361937.n4.nabble.com/nifi-hive-nar-1-7-1-nar-will-not-load-td5337.html

The suggested workaround is to specify a different `-Djava.io.tmpdir` in bootstrap.conf. Made that configurable in this role by adding an optional `nifi_tmpdir` property.