### PR TITLE
Suppress always starting NiFi, rely on handler and nifi_perform_restart property

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -28,8 +28,8 @@
     - { src: "{{ nifi_major_version }}/nifi.sh.j2", dest: "{{ nifi_home }}/bin/nifi.sh" }
     - { src: "{{ nifi_major_version }}/nifi-env.sh.j2", dest: "{{ nifi_home }}/bin/nifi-env.sh" }
 
-- name: Ensure NiFi is running
-  service: name=nifi state=started enabled=yes
+- name: Ensure NiFi service starts on reboot
+  service: name=nifi enabled=yes
 
 - name: Ensure NiFi is restarted
   service: name=nifi state=restarted


### PR DESCRIPTION
We have an edge case occurring during an initial installation. We have both `nifi_perform_restart` and `nifi_force_restart` set to `False` as we wish to perform additional configuration after the role completes, and then manage starting/restarting nifi elsewhere. This works fine for updates. But for an initial installation, or if for some reason nifi is stopped, the role always starts nifi regardless of the property settings.

This commit simply removes the behavior that always starts nifi, and instead relies on the handler where the `nifi_perform_restart` property is honored.