### PR TITLE
Create embedded zookeeper subdir to avoid race conditions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -48,7 +48,10 @@
   with_items: "{{ nifi_provenance_repositories }}"
 
 - name: ensure zookeeper data directory exists
-  file: path="{{ nifi_zookeeper_dir }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
+  file: path="{{ item }}" state=directory owner="{{ nifi_user }}" group="{{ nifi_user }}" mode=0755
+  with_items:
+    - "{{ nifi_zookeeper_dir }}"
+    - "{{ nifi_zookeeper_dir }}/version-2"
   when: nifi_state_management_embedded_zookeeper_start
 
 - name: add myid file for embedded zookeeper


### PR DESCRIPTION
On a fresh install of NiFi 1.9, using embedded Zookeeper, we encountered the first issue described at the bottom of [this page](https://bryanbende.com/development/2018/10/23/apache-nifi-secure-cluster-setup). It seems that there is a race condition in the embedded Zookeeper creating a required directory. A simple restart fixes the issue, as outlined on that page, but the fix in this PR seems safe enough to perform as part of the installation.