### PR TITLE
Allow ldap authentication to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ Role Variables
     nifi_log_level_org_wali: WARN
     nifi_custom_log_levels: []
 
+    # LDAP authentication settings
+    # (only used if nifi_security_user_login_identity_provider is set to "ldap-provider")
+    nifi_ldap_provider_authentication_strategy: START_TLS
+    nifi_ldap_provider_manager_dn:
+    nifi_ldap_provider_manager_password:
+    nifi_ldap_provider_tls_keystore:
+    nifi_ldap_provider_tls_keystore_password:
+    nifi_ldap_provider_tls_keystore_type:
+    nifi_ldap_provider_tls_truststore:
+    nifi_ldap_provider_tls_truststore_password:
+    nifi_ldap_provider_tls_truststore_type:
+    nifi_ldap_provider_tls_client_auth:
+    nifi_ldap_provider_tls_protocol:
+    nifi_ldap_provider_tls_shutdown_gracefully:
+    nifi_ldap_provider_referral_strategy: FOLLOW
+    nifi_ldap_provider_connect_timeout: 10 secs
+    nifi_ldap_provider_read_timeout: 10 secs
+    nifi_ldap_provider_url:
+    nifi_ldap_provider_user_search_base:
+    nifi_ldap_provider_user_search_filter:
+    nifi_ldap_provider_identity_strategy: USE_DN
+    nifi_ldap_provider_authentication_expiration: 12 hours
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,6 +111,7 @@ nifi_security_keyPasswd: "{{ nifi_security_keystorePasswd }}"
 nifi_security_truststore: "{{ nifi_conf_dir }}/truststore.jks"
 nifi_security_truststoreType: jks
 nifi_security_truststorePasswd: ''
+nifi_security_user_login_identity_provider:
 
 # Logback logging levels and settings
 nifi_log_app_file_retention: 10
@@ -138,3 +139,26 @@ nifi_custom_log_levels: []
 
 # Extra Properties
 nifi_variable_registry_properties: [ "{{ nifi_conf_dir }}/extra-args.properties" ]
+
+# LDAP authentication settings
+# (only used if nifi_security_user_login_identity_provider is set to "ldap-provider")
+nifi_ldap_provider_authentication_strategy: START_TLS
+nifi_ldap_provider_manager_dn:
+nifi_ldap_provider_manager_password:
+nifi_ldap_provider_tls_keystore:
+nifi_ldap_provider_tls_keystore_password:
+nifi_ldap_provider_tls_keystore_type:
+nifi_ldap_provider_tls_truststore:
+nifi_ldap_provider_tls_truststore_password:
+nifi_ldap_provider_tls_truststore_type:
+nifi_ldap_provider_tls_client_auth:
+nifi_ldap_provider_tls_protocol:
+nifi_ldap_provider_tls_shutdown_gracefully:
+nifi_ldap_provider_referral_strategy: FOLLOW
+nifi_ldap_provider_connect_timeout: 10 secs
+nifi_ldap_provider_read_timeout: 10 secs
+nifi_ldap_provider_url:
+nifi_ldap_provider_user_search_base:
+nifi_ldap_provider_user_search_filter:
+nifi_ldap_provider_identity_strategy: USE_DN
+nifi_ldap_provider_authentication_expiration: 12 hours

--- a/templates/1.10/login-identity-providers.xml.j2
+++ b/templates/1.10/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.10/nifi.properties.j2
+++ b/templates/1.10/nifi.properties.j2
@@ -189,7 +189,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}{{ nifi_security_user_login_identity_provider }}{{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.11/login-identity-providers.xml.j2
+++ b/templates/1.11/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.11/nifi.properties.j2
+++ b/templates/1.11/nifi.properties.j2
@@ -198,7 +198,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.12/login-identity-providers.xml.j2
+++ b/templates/1.12/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.12/nifi.properties.j2
+++ b/templates/1.12/nifi.properties.j2
@@ -195,7 +195,7 @@ nifi.security.truststorePasswd=
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
 nifi.security.allow.anonymous.authentication=false
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.13/login-identity-providers.xml.j2
+++ b/templates/1.13/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.13/nifi.properties.j2
+++ b/templates/1.13/nifi.properties.j2
@@ -195,7 +195,7 @@ nifi.security.truststorePasswd=
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
 nifi.security.allow.anonymous.authentication=false
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.3/login-identity-providers.xml.j2
+++ b/templates/1.3/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
-    <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2.
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
+    <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
+        
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
-
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.3/nifi.properties.j2
+++ b/templates/1.3/nifi.properties.j2
@@ -181,7 +181,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth=
 nifi.security.user.authorizer=file-provider
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.4/login-identity-providers.xml.j2
+++ b/templates/1.4/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.4/nifi.properties.j2
+++ b/templates/1.4/nifi.properties.j2
@@ -180,7 +180,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.5/login-identity-providers.xml.j2
+++ b/templates/1.5/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.5/nifi.properties.j2
+++ b/templates/1.5/nifi.properties.j2
@@ -185,7 +185,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.6/login-identity-providers.xml.j2
+++ b/templates/1.6/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.6/nifi.properties.j2
+++ b/templates/1.6/nifi.properties.j2
@@ -186,7 +186,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.7/login-identity-providers.xml.j2
+++ b/templates/1.7/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.7/nifi.properties.j2
+++ b/templates/1.7/nifi.properties.j2
@@ -189,7 +189,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.8/login-identity-providers.xml.j2
+++ b/templates/1.8/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.8/nifi.properties.j2
+++ b/templates/1.8/nifi.properties.j2
@@ -189,7 +189,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 

--- a/templates/1.9/login-identity-providers.xml.j2
+++ b/templates/1.9/login-identity-providers.xml.j2
@@ -63,37 +63,41 @@
             for. If the user never logs out, they will be required to log back in following
             this duration.
     -->
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     <!-- To enable the ldap-provider remove 2 lines. This is 1 of 2. 
+{% endif %}
     <provider>
         <identifier>ldap-provider</identifier>
         <class>org.apache.nifi.ldap.LdapProvider</class>
-        <property name="Authentication Strategy">START_TLS</property>
+        <property name="Authentication Strategy">{{ nifi_ldap_provider_authentication_strategy }}</property>
 
-        <property name="Manager DN"></property>
-        <property name="Manager Password"></property>
+        <property name="Manager DN">{{ nifi_ldap_provider_manager_dn }}</property>
+        <property name="Manager Password">{{ nifi_ldap_provider_manager_password }}</property>
 
-        <property name="TLS - Keystore"></property>
-        <property name="TLS - Keystore Password"></property>
-        <property name="TLS - Keystore Type"></property>
-        <property name="TLS - Truststore"></property>
-        <property name="TLS - Truststore Password"></property>
-        <property name="TLS - Truststore Type"></property>
-        <property name="TLS - Client Auth"></property>
-        <property name="TLS - Protocol"></property>
-        <property name="TLS - Shutdown Gracefully"></property>
+        <property name="TLS - Keystore">{{ nifi_ldap_provider_tls_keystore }}</property>
+        <property name="TLS - Keystore Password">{{ nifi_ldap_provider_tls_keystore_password }}</property>
+        <property name="TLS - Keystore Type">{{ nifi_ldap_provider_tls_keystore_type }}</property>
+        <property name="TLS - Truststore">{{ nifi_ldap_provider_tls_truststore }}</property>
+        <property name="TLS - Truststore Password">{{ nifi_ldap_provider_tls_truststore_password }}</property>
+        <property name="TLS - Truststore Type">{{ nifi_ldap_provider_tls_truststore_type }}</property>
+        <property name="TLS - Client Auth">{{ nifi_ldap_provider_tls_client_auth }}</property>
+        <property name="TLS - Protocol">{{ nifi_ldap_provider_tls_protocol }}</property>
+        <property name="TLS - Shutdown Gracefully">{{ nifi_ldap_provider_tls_shutdown_gracefully }}</property>
         
-        <property name="Referral Strategy">FOLLOW</property>
-        <property name="Connect Timeout">10 secs</property>
-        <property name="Read Timeout">10 secs</property>
+        <property name="Referral Strategy">{{ nifi_ldap_provider_referral_strategy }}</property>
+        <property name="Connect Timeout">{{ nifi_ldap_provider_connect_timeout }}</property>
+        <property name="Read Timeout">{{ nifi_ldap_provider_read_timeout }}</property>
 
-        <property name="Url"></property>
-        <property name="User Search Base"></property>
-        <property name="User Search Filter"></property>
+        <property name="Url">{{ nifi_ldap_provider_url }}</property>
+        <property name="User Search Base">{{ nifi_ldap_provider_user_search_base }}</property>
+        <property name="User Search Filter">{{ nifi_ldap_provider_user_search_filter }}</property>
 
-        <property name="Identity Strategy">USE_DN</property>
-        <property name="Authentication Expiration">12 hours</property>
+        <property name="Identity Strategy">{{ nifi_ldap_provider_identity_strategy }}</property>
+        <property name="Authentication Expiration">{{ nifi_ldap_provider_authentication_expiration }}</property>
     </provider>
+{% if nifi_security_user_login_identity_provider != "ldap-provider" %}
     To enable the ldap-provider remove 2 lines. This is 2 of 2. -->
+{% endif %}
 
     <!--
         Identity Provider for users logging in with username/password against a Kerberos KDC server.

--- a/templates/1.9/nifi.properties.j2
+++ b/templates/1.9/nifi.properties.j2
@@ -190,7 +190,7 @@ nifi.security.truststorePasswd=
 {% endif -%}
 nifi.security.needClientAuth={{ nifi_need_client_auth | default('')}}
 nifi.security.user.authorizer=managed-authorizer
-nifi.security.user.login.identity.provider=
+nifi.security.user.login.identity.provider={{ nifi_security_user_login_identity_provider }}
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
 


### PR DESCRIPTION
Initial PR that allows the role to configure NiFi to use LDAP authentication.

Will look at extending this PR with another commit to enable the `ldap-user-group-provider` to be used for authorization.