### PR TITLE
Removed NiFi user's home dir, set default shell to /sbin/nologin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,15 @@ Role Variables
     nifi_etc_dir: /etc/nifi
     nifi_log_dir: /var/log/nifi
     nifi_pid_dir: /var/run/nifi
+    nifi_home_dir: /home/nifi
     
 ### Other Default variables are listed below:
+
+    # Whether to create a home dir for the NiFi service user. Defaults to true to preserve prior functionality, but should be set to false for new instances.
+    nifi_create_home_dir: true 
+
+    # Sets the default shell for the NiFi service user. Only takes affect if nifi_create_home_dir is true.
+    nifi_default_shell: /bin/bash
 
     # specify -Djava.io.tmpdir in bootstrap.conf, default is unspecified
     #nifi_tmp_dir: /tmp

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,11 @@
 # defaults file for nifi
 nifi_major_version: "{{ nifi_version | splitext | first }}"
 
+# NiFi service user settings
+nifi_create_home_dir: True
+nifi_home_dir: "/home/{{ nifi_user }}"
+nifi_default_shell: /bin/bash
+
 # installation locations
 nifi_base_dir: /opt/nifi
 nifi_etc_dir: /etc/nifi

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
   tags: [ user ]
 
 - name: ensure nifi user exists
-  user: name="{{ nifi_user }}" group="{{ nifi_user }}" shell="/bin/bash" home="/home/nifi"
+  user: name="{{ nifi_user }}" group="{{ nifi_user }}" shell="/sbin/nologin" create_home=false
   tags: [ user ]
 
 # tasks file for nifi

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,12 @@
   tags: [ user ]
 
 - name: ensure nifi user exists
-  user: name="{{ nifi_user }}" group="{{ nifi_user }}" shell="/sbin/nologin" create_home=false
+  user: 
+    name: "{{ nifi_user }}"
+    group: "{{ nifi_user }}"
+    shell: "{{ nifi_create_home_dir | ternary(nifi_default_shell, '/sbin/nologin') }}"
+    home:  "{{ nifi_home_dir }}"
+    create_home: "{{ nifi_create_home_dir }}"
   tags: [ user ]
 
 # tasks file for nifi


### PR DESCRIPTION
Service users aren't supposed to have a login shell or a home directory for security reasons. This PR:
1. Sets the nifi user to not have a home directory, and
2. Sets the nifi user's default shell to /sbin/nologin, giving it no default shell.

The team I'm on, up until fairly recently, used a 2-year-old version of this repo from before this role was responsible with making the service user, and we've had the service user set up this way the whole time. Now that we're updating the repo(finally), we thought it'd be a good idea to contribute this change back.

This does require NiFi to be stopped in order to run, as you can't add or remove the home directory of a user with running processes. This *might* be the real reason I made this PR, but it's a good idea to remove it anyways :)